### PR TITLE
Move dropped sets up & hide them behind a link

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -64,12 +64,21 @@ a.tip:after {
   color: #666;
 }
 
+.label-low-distraction {
+  background-color: #fff;
+  color: #ddd;
+}
+
 /*
  * set list
  */
 
 ul.list-group > li.gray {
   color: #ddd;
+}
+
+div.recently-dropped-toggle-container {
+  text-align: right;
 }
 
 /*
@@ -87,8 +96,21 @@ span.badge > img {
   height: 21px;
 }
 
+ul.list-group > li.list-group-item.gray > span.badge > img {
+  opacity: .2;
+}
+
 .badge {
   background: none;
+}
+
+/*
+ * low-distraction links
+ */
+a.low-distraction {
+  color: #ddd;
+  font-size: .8em;
+  text-decoration: none;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -17,6 +17,30 @@
         </div>
       </div>
       <div class="col-md-5">
+        <div class="recently-dropped-toggle-container">
+          <a href="#" class="low-distraction" onclick="$('#recently-dropped').toggle();">show recently dropped sets</a>
+        </div>
+        <ul id="recently-dropped" class="list-group" style="display: none;">
+          <li class="list-group-item gray">
+            Theros
+            <span class="badge"><img src="img/ths.svg" /></span>
+          </li>
+          <li class="list-group-item gray">
+            Born of the Gods
+            <span class="badge"><img src="img/bng.svg" /></span>
+          </li>
+          <li class="list-group-item gray">
+            Journey into Nyx
+            <span class="badge"><img src="img/jou.svg" /></span>
+          </li>
+          <li class="list-group-item gray">
+            2015 Core Set
+            <span class="badge"><img src="img/m15.svg" /></span>
+          </li>
+          <span class="label label-low-distraction">
+            Dropped October 2015
+          </span>
+        </ul>
         <ul class="list-group">
           <li class="list-group-item">
             Khans of Tarkir
@@ -53,27 +77,6 @@
           </li>
           <span class="label label-default">
             Oath of the Gatewatch releases January 22, 2016
-          </span>
-        </ul>
-	<ul class="list-group">
-          <li class="list-group-item gray">
-            Theros
-            <span class="badge"><img src="img/ths.svg" /></span>
-          </li>
-          <li class="list-group-item gray">
-            Born of the Gods
-            <span class="badge"><img src="img/bng.svg" /></span>
-          </li>
-          <li class="list-group-item gray">
-            Journey into Nyx
-            <span class="badge"><img src="img/jou.svg" /></span>
-          </li>
-          <li class="list-group-item gray">
-            2015 Core Set
-            <span class="badge"><img src="img/m15.svg" /></span>
-          </li>
-          <span class="label label-warning">
-            Latest rotation out of Standard 
           </span>
         </ul>
       </div>


### PR DESCRIPTION
Hey, per my comment on glacials/whatsinstandard#15, I thought about how I'd like the "recently dropped sets" info to show without adding distractions from the main purpose of the page. I fooled around a bit and came up with something that is mostly distraction-free, but since this is your feature I'd like to see what you think about it.

The changes against your original PR are:
- Move the list up to the top (I agree with @nightfirecat on this; the page should be a timeline)
- Lower the opacity of the set icons for the dropped sets
- Don't show the list by default; hide it behind a JS link instead

Here's what it looks like before clicking the "show" link:

<img width="556" alt="screenshot 2015-11-08 16 51 56" src="https://cloud.githubusercontent.com/assets/438911/11023888/fb0eb52c-8638-11e5-9522-9ffa206860b0.png">

And after:

<img width="556" alt="screenshot 2015-11-08 16 52 17" src="https://cloud.githubusercontent.com/assets/438911/11023889/004e1dca-8639-11e5-8209-da05bad94651.png">

Let me know what you think about this.
